### PR TITLE
Issue #8 prefect api now initializes key; tests pass

### DIFF
--- a/src/PrefectInterfaces.jl
+++ b/src/PrefectInterfaces.jl
@@ -34,6 +34,7 @@ module PrefectInterfaces
 
 abstract type AbstractPrefectInterface end
 abstract type AbstractPrefectBlock <: AbstractPrefectInterface end
+abstract type AbstractPrefectConfig <: AbstractPrefectInterface end
 
 export  AbstractPrefectInterface,
         AbstractPrefectBlock,
@@ -50,9 +51,9 @@ export  AbstractPrefectInterface,
         getblock,
         makeblock
         
+include("prefectblock/prefectblocktypes.jl")
 include("config.jl")
 include("prefectblock/prefectblock.jl")
-include("prefectblock/prefectblocktypes.jl")
 include("Datasets/Datasets.jl")
 
 using   .Datasets

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,7 +1,9 @@
 """
-    PrefectAPI(url::String) <:AbstractPrefectInterface
+    PrefectAPI(url::String, key::SecretString) <:AbstractPrefectInterface
 
-Mutable struct tha stores the Prefect server api endpoint. All `PrefectInterface` operations depend on connecting to a running Prefect server to pull block information. Constructor with no arguments assigns env variable `PREFECT_API_URL` to url field.
+Mutable struct tha stores the Prefect server api endpoint. All `PrefectInterface` operations depend on connecting to a running Prefect server to pull block information. Constructor with no arguments assigns env variables `PREFECT_API_URL`, `PREFECT_API_KEY`
+    
+If `PREFECT_API_KEY` does not exist then an empty string is assigned to `key`. For Prefect Server with no authentication (or with auth managed by connection string) the empty key will not interfere with API calls.
 
 # Examples:
 ```jldoctest
@@ -10,33 +12,49 @@ julia> using PrefectInterfaces
 julia> ENV["PREFECT_API_URL"] = "http://127.0.0.1:4300/api";
 
 julia> api = PrefectAPI()
-PrefectAPI("http://127.0.0.1:4300/api")
+PrefectAPI("http://127.0.0.1:4300/api", ####Secret####)
 
 julia> api.url
 "http://127.0.0.1:4300/api"
 
-julia> api.url = "http://127.0.0.1:4333/api"
-"http://127.0.0.1:4333/api"
+julia> api.key.secret
+""
 
-julia> PrefectAPI("http://127.0.0.1:4444/api").url
-"http://127.0.0.1:4444/api"
+julia> api.url = "https://api.prefect.cloud/api/accounts/0eEXAMPLE";
+
+julia> api.key = SecretString("abcd1234")
+####Secret####
+
+julia> api = PrefectAPI("https://api.prefect.cloud/api/accounts/0eEXAMPLE", "abcd1234")
+PrefectAPI("https://api.prefect.cloud/api/accounts/0eEXAMPLE", ####Secret####)
 ```
 """
-mutable struct PrefectAPI <: AbstractPrefectInterface
+mutable struct PrefectAPI <: AbstractPrefectConfig
     url::AbstractString
+    key::SecretString
+    PrefectAPI(url, key) = new(url, SecretString(key))
 end
+PrefectAPI(url) = PrefectAPI(url, "")
 PrefectAPI() = begin
-    if haskey(ENV, "PREFECT_API_URL")
+    if ! haskey(ENV, "PREFECT_API_URL")
+        @warn "Prefect API URL is needed to call Prefect Server.\n" *
+        "Zero-argument constructor requires ENV value PREFECT_API_URL optional PREFECT_API_KEY."
+    end
+    if ! haskey(ENV, "PREFECT_API_KEY")
         PrefectAPI(ENV["PREFECT_API_URL"])
     else
-        @warn "Prefect API URL is needed to call Prefect Server.\n" *
-            "Set ENV variable PREFECT_API_URL or provide endpoint URL to this constructor."
-        throw(KeyError("PREFECT_API_URL"))
+        PrefectAPI(ENV["PREFECT_API_URL"], ENV["PREFECT_API_KEY"])
     end
 end
 
 
 # TODO: so far not used anywhere. idea is a type to load env with dotenv when contstructor is called.
-struct PrefectConfig <: AbstractPrefectInterface
+# maybe PrefectConfig is a global struct to hold config and is accessible without passing in and 
+#   out of a bunch of function calls. simply the model and changes get easier.
+#   it makes it more sensible when handing off from python shell call to an included file
+#   you cant pass parameters to an included file but you want access to parameters passed from 
+#   prefect flows.
+#   Every PrefectInterfaces session has a PrefectConfig.init() action or some initialization.
+struct PrefectConfig <: AbstractPrefectConfig
     env::Dict
 end

--- a/src/prefectblock/prefectblocktypes.jl
+++ b/src/prefectblock/prefectblocktypes.jl
@@ -32,6 +32,30 @@ end
 Base.show(io::IO, s::SecretString) = print(io, "####Secret####")
 Base.dump(io::IOContext, s::SecretString, n::Int64, indent) = print(io, "SecretString")
 
+"""
+    SecretBlock(blockname::String, blocktype::String, value::SecretString) <: AbstractPrefectBlock
+
+A struct for storing a Prefect Block with a SecretString as value field. This permits retrieving secrets from the Prefect Server/Prefect Cloud. The secret field is accessible via the `value.secret` field.
+
+*NOTE:* This is not an ecrypted secrets store, it is a log obfuscator.
+
+# Example:
+```jldoctest
+julia> using PrefectInterfaces
+
+julia> secretblock = SecretBlock("secret", "necromancer", "abcd1234")
+SecretBlock("secret", "necromancer", ####Secret####)
+
+julia> dump(secretblock, maxdepth = 10)
+SecretBlock
+  blockname: String "secret"
+  blocktype: String "necromancer"
+  value: SecretString
+
+julia> secretblock.value.secret
+"abcd1234"
+```
+"""
 struct SecretBlock <: AbstractPrefectBlock
     blockname::String
     blocktype::String

--- a/test/config/config.jl
+++ b/test/config/config.jl
@@ -1,11 +1,22 @@
 using PrefectInterfaces
 using PrefectInterfaces.Datasets
 
-@test PrefectAPI("http://127.0.0.1:4444/api").url == "http://127.0.0.1:4444/api"
+# PrefectAPI
 api = PrefectAPI()
 @test api.url == "http://127.0.0.1:4300/api"
 @test typeof(api) == PrefectAPI
 
+    # single arg constructor
+@test PrefectAPI("http://127.0.0.1:4444/api").url == "http://127.0.0.1:4444/api"
+@test PrefectAPI("http://127.0.0.1:4444/api").key.secret == ""
+
+    # url and key argument constructor
+api = PrefectAPI("https://api.prefect.cloud/api/accounts/0eEXAMPLE", "abcd1234")
+@test api.url == "https://api.prefect.cloud/api/accounts/0eEXAMPLE"
+@test repr(api.key) == "####Secret####"
+@test api.key.secret == "abcd1234"
+
+# Datasets
 dst = Datasets.PrefectDatastoreNames()
 @test propertynames(dst) == (:remote, :local)
 @test dst.remote == "s3-bucket/willowdata"

--- a/todo/DONE.md
+++ b/todo/DONE.md
@@ -37,3 +37,34 @@ x = settings.PREFECT_API_URL.value()
 'http://127.0.0.1:4300/api'
 ```
 So it works. The julia application needs to receive this value as a parameter.
+
+## DONE: SECRETBLOCK OBFUSCATE DUMP
+Issue #9
+
+DONE: override dump to obscure SecretBlock from logs
+```jl
+sblk = SecretBlock("poo", "patype", "abc123")
+SecretBlock("poo", "patype", ####Secret####)
+
+show(sblk)
+SecretBlock("poo", "patype", ####Secret####)
+dump(sblk)
+SecretBlock
+  blockname: String "poo"
+  blocktype: String "patype"
+  value: SecretString
+    secret: String "abc123"
+
+Base.dump(io::IOContext, s::SecretString, n::Int64, indent) = print(io, "SecretString")
+dump(sblk)
+# SecretBlock
+#   blockname: String "poo"
+#   blocktype: String "patype"
+#   value: SecretString
+dump(sblk, maxdepth = 4)
+# SecretBlock
+#   blockname: String "poo"
+#   blocktype: String "patype"
+#   value: SecretString
+```
+DONE

--- a/todo/TODO.md
+++ b/todo/TODO.md
@@ -1,0 +1,4 @@
+# TODO
+Not quite issues, but on the list.
+There are some sprinkled throughout the repo.
+

--- a/todo/issues/issue-8.bugfix-authentication.md
+++ b/todo/issues/issue-8.bugfix-authentication.md
@@ -1,0 +1,194 @@
+# Bugfix: PrefectInterfaces authenticate to cloud
+* dataframe jobs failing
+* makeblock error
+
+## TOPLINE
+1. Strategy is add a header argument for API KEY, which if empty will work also for local instance
+2. DONE: how to introduce API besides ENV variables. PrefectAPI struct, will move to a global config struct later.
+
+
+## BUGFIX DOCUMENTATION
+    $HOME/.julia/dev/PrefectInterfaces/src/prefectblock/prefectblock.jl
+```jl
+revise()
+
+api = PrefectAPI("https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce", "pnu_o3RM3DqDGdvGYfIGEJBir0AsCtnIAk4bO9nR")
+PrefectAPI("https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce", ####Secret####)
+
+ls(api=api)
+(blocks = ["aws-credentials/app-templisher", "credentialpair/trino-creds", "github/cloud", "github/ikeloa-tables-cloud", "local-file-system/datastore", "local-file-system/idioteque", "process/idioteque", "s3-bucket/datastore", "secret/gserviceacct-ikeloa-reports", "slack-webhook/ikeloa-alert-tests", "slack-webhook/ikeloa-alerts", "slack-webhook/zhl-growth-and-experience-wbr", "string/environment"],)
+
+ans.blocks
+13-element Vector{String}:
+ "aws-credentials/app-templisher"
+ "credentialpair/trino-creds"
+ "github/cloud"
+ "github/ikeloa-tables-cloud"
+ "local-file-system/datastore"
+ "local-file-system/idioteque"
+ "process/idioteque"
+ "s3-bucket/datastore"
+ "secret/gserviceacct-ikeloa-reports"
+ "slack-webhook/ikeloa-alert-tests"
+ "slack-webhook/ikeloa-alerts"
+ "slack-webhook/zhl-growth-and-experience-wbr"
+ "string/environment"
+
+ls(api=api)
+(blocks = ["aws-credentials/app-templisher", "credentialpair/trino-creds", "github/cloud", "github/ikeloa-tables-cloud", "local-file-system/datastore", "local-file-system/idioteque", "process/idioteque", "s3-bucket/datastore", "secret/gserviceacct-ikeloa-reports", "slack-webhook/ikeloa-alert-tests", "slack-webhook/ikeloa-alerts", "slack-webhook/zhl-growth-and-experience-wbr", "string/environment"],)
+
+ab = getblock("credentialpair/trino-creds", api=api)
+Dict{String, Any} with 12 entries:
+  "block_type_id"             => "94a978e3-6f80-406b-ab19-54ccd8a6ba54"
+  "block_type_name"           => "CredentialPair"
+  "data"                      => Dict{String, Any}("secret_key"=>"xxxxxxx", "id"=>"_ikeloa-trino")
+  "block_schema"              => Dict{String, Any}("block_type_id"=>"94a978e3-6f80-406b-ab19-54ccd8a6ba54", "block_type"=>Dict{String, Any}("logo_url"=>"https://i.imgur.com/ArhWDVr.png", "name"=>"Credent…
+  "is_anonymous"              => false
+  "name"                      => "trino-creds"
+  "block_type"                => Dict{String, Any}("logo_url"=>"https://i.imgur.com/ArhWDVr.png", "name"=>"CredentialPair", "code_example"=>"python\nfrom src.blocks.classes.credential_pair import Cred…
+  "id"                        => "19726768-a37d-425c-9fd8-eb63fbe339d6"
+  "created"                   => "2023-11-21T20:54:36.461919+00:00"
+  "updated"                   => "2023-11-21T20:54:36.461935+00:00"
+  "block_document_references" => Dict{String, Any}()
+  "block_schema_id"           => "d978b0b4-fb89-4947-adf7-bab8f0dd8435"
+
+# Now that PrefectBlock can be constructed from default (dev local) or with api = PrefectAPI
+ENV["PREFECT_API_URL"] = "http://127.0.0.1:4204/api";
+devls = ls();
+devls.blocks
+13-element Vector{String}:
+ "aws-credentials/app-templisher"
+ "credentialpair/trino-creds"
+ "github/dev"
+ "github/ikeloa-tables-dev"
+ "local-file-system/datastore"
+ "local-file-system/idioteque"
+ "process/idioteque"
+ "s3-bucket/datastore"
+ "secret/gserviceacct-ikeloa-reports"
+ "slack-webhook/ikeloa-alert-tests"
+ "slack-webhook/ikeloa-alerts"
+ "slack-webhook/zhl-growth-and-experience-wbr"
+ "string/environment"
+
+fsblock2 = PrefectBlock("local-file-system/idioteque")
+PrefectBlock("local-file-system/idioteque", LocalFSBlock("local-file-system/idioteque", "local-file-system", "/Users/merlinr/prefect-local-deployment/dev", PrefectInterfaces.var"#1#3"{String}("/Users/merlinr/prefect-local-deployment/dev"), PrefectInterfaces.var"#2#4"{String}("/Users/merlinr/prefect-local-deployment/dev")))
+
+dump(fsblock2)
+PrefectBlock
+  blockname: String "local-file-system/idioteque"
+  block: LocalFSBlock
+    blockname: String "local-file-system/idioteque"
+    blocktype: String "local-file-system"
+    basepath: String "/Users/merlinr/prefect-local-deployment/dev"
+    read_path: #1 (function of type PrefectInterfaces.var"#1#3"{String})
+      basepath: String "/Users/merlinr/prefect-local-deployment/dev"
+    write_path: #2 (function of type PrefectInterfaces.var"#2#4"{String})
+      basepath: String "/Users/merlinr/prefect-local-deployment/dev"
+```
+
+## REPRODUCE
+My calls to the PrefectDB have been using a local zero-authentication endpoint.
+Methods that call the PrefectDB need to provide the PREFECT_API_KEY to authenticate.
+
+```jl
+PREFECT_API_URL
+PREFECT_API_KEY
+# both present in ENV
+
+using PrefectInterfaces
+
+PrefectAPI()
+# PrefectAPI("http://127.0.0.1:4204/api")
+ENV["PREFECT_API_URL"]="https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce"
+
+ls()
+┌ Warning: no connection.
+│   api_url = "https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce"
+└ @ PrefectInterfaces ~/.julia/packages/PrefectInterfaces/T1HiK/src/prefectblock/prefectblock.jl:101
+HTTP.Exceptions.StatusError(403, "POST", "/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce/block_documents/filter", HTTP.Messages.Response:
+"""
+HTTP/1.1 403 Forbidden
+...
+{"detail":"Not authenticated"}""")
+```
+
+## FIX HTTP REQUEST HEADER
+[Prefect REST API Docs](https://docs.prefect.io/latest/api-ref/rest-api/)
+
+```jl
+# request should have (python)
+headers = {"Authorization": f"Bearer {PREFECT_API_KEY}"}
+
+# HTTP.jl
+HTTP.request(method, url [, headers [, body]]; <keyword arguments>])
+
+# so ls() has
+api_key = ENV["PREFECT_API_KEY"]
+api_url = ENV["PREFECT_API_URL"]
+resp = HTTP.request(
+    "POST"
+    , "$(api_url)/block_documents/filter"
+    ,   
+    , copyheaders=false
+)
+# HTTP/1.1 200 OK
+# 
+
+# AND if there is no KEY, such as for local instance, blank field is all right:
+resp = HTTP.request(
+    "POST"
+    , "http://127.0.0.1:4204/api/block_documents/filter"
+    , ["Authorization" => ""]
+    , copyheaders=false
+)
+# also with => "Bearer " still returns result:
+# block_type_id" => "88350020-5271-4070-8092-59e191fd2897", "block_type_name" => "AWS Credentials"
+just use dev
+just pre block ls
+# "id" => "9fc99174-6c3a-4cae-9d42-2f41cdc4d3e6"
+# this is from dev environment on port 4204
+# PASS
+```
+
+## TRY LS AGAIN WITH NEW PREFECTAPI FIX
+```jl
+# from cloud api docs
+https://api.prefect.cloud/api/accounts/{account_id}/workspaces/{workspace_id}/block_documents/filter
+# profile.toml
+PREFECT_API_URL = "https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce"
+
+api = PrefectAPI("https://api.prefect.cloud/api/accounts/0e3aff3a-16ab-411f-baed-2982e4c82ebd/workspaces/0cd79ef6-aa52-43f7-8357-0f8dc0ff30ce", "xxxxxx")
+
+resp = HTTP.post(
+    "$(api.url)/block_documents/filter"
+    , ["Authorization" => "Bearer $(api.key.secret)"]
+    , copyheaders=false
+)
+HTTP.Messages.Response:
+HTTP/1.1 200 OK
+
+resp.body   # has all the information
+using JSON
+blockdata = JSON.parse(String(resp.body))
+# yup its all there
+```
+DONE.
+
+## HEALTH CHECK
+For tests
+```jl
+# From ReDoc API
+https://api.prefect.cloud/api/accounts/{account_id}/workspaces/{workspace_id}/health
+
+
+check = HTTP.get(ENV["PREFECT_API_URL"] * "/health", ["Authorization" => "Bearer $api_key"])
+# 200 OK
+
+# for local Prefect
+check = HTTP.get("http://127.0.0.1:4204/health", ["Authorization" => "Bearer "])
+# 200 OK
+check.status
+# 200
+
+```


### PR DESCRIPTION
* Changed PrefectAPI to a struct holding url and key (as a SecretString)
* updated `get_block` and `PrefectBlock` constructors
* updated jldoctest
* added tests for config.jl
* tests all passing